### PR TITLE
changed default message to english

### DIFF
--- a/frontend/src/components/DocView/FileViewer.tsx
+++ b/frontend/src/components/DocView/FileViewer.tsx
@@ -12,7 +12,7 @@ interface FileViewerProps {
 
 const FileViewer: React.ComponentType<FileViewerProps> = ({ file, fileType, page }) => {
     console.log("Filetipe", fileType);
-    let ViewerComponent: React.ComponentType<any> = () => <div>No hay visor disponible para este tipo de archivo.</div>;
+    let ViewerComponent: React.ComponentType<any> = () => <div>There is no viewer available for this type of file.</div>;
 
     let componentProps = { file, fileType, page };
 


### PR DESCRIPTION
This pull request includes a small change to the `FileViewer` component to improve the user interface by updating the message displayed when no viewer is available for a file type.

* [`frontend/src/components/DocView/FileViewer.tsx`](diffhunk://#diff-854947d2c39a0502488406de7aeb39b585a844c17d624eaa194c2ebfa37cbe3cL15-R15): Changed the message from "No hay visor disponible para este tipo de archivo." to "There is no viewer available for this type of file."