### PR TITLE
Added isWorkMode

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -12,6 +12,7 @@ export async function chatApiGpt(options: ChatRequestGpt): Promise<AskResponseGp
             history: options.history,
             approach: options.approach,
             conversation_id: options.conversation_id,
+            is_work_mode: options.is_work_mode,
             query: options.query,
             overrides: {
                 semantic_ranker: options.overrides?.semanticRanker,

--- a/frontend/src/api/models.ts
+++ b/frontend/src/api/models.ts
@@ -58,6 +58,7 @@ export type ChatTurn = {
 
 export type ChatRequest = {
     history: ChatTurn[];
+    is_work_mode: boolean;
     approach: Approaches;
     overrides?: AskRequestOverrides;
 };
@@ -65,6 +66,7 @@ export type ChatRequest = {
 export type ChatRequestGpt = {
     history: ChatTurn[];
     approach: Approaches;
+    is_work_mode: boolean;
     conversation_id: string;
     query: string;
     overrides?: AskRequestOverrides;

--- a/frontend/src/pages/chat/Chat.module.css
+++ b/frontend/src/pages/chat/Chat.module.css
@@ -113,3 +113,72 @@
     margin-right: 20px;
     margin-bottom: 20px;
 }
+
+.commandToggle {
+    margin-right: 10px;
+}
+
+.toggleContainer {
+    display: flex;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-right: 10px;
+    border: 1px solid var(--border-color);
+}
+
+.toggleButton {
+    padding: 6px 12px;
+    cursor: pointer;
+    background-color: var(--bg-color);
+    transition: background-color 0.2s ease;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.toggleButtonActive {
+    background-color: var(--primary-color);
+    color: white;
+}
+
+.toggleText {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.modeToggleContainer {
+    display: flex;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-right: 10px;
+    border: 1px solid #ccc;
+    justify-content: center;
+}
+
+#mode-work {
+    margin: 0 auto;
+}
+
+.modeToggleButton {
+    padding: 6px 12px;
+    cursor: pointer;
+    background-color: #f2f2f2;
+    transition: background-color 0.2s ease;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.activeMode {
+    background-color: #0078d4;
+    color: white;
+}
+
+.modeToggleText {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 500;
+}

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -293,7 +293,7 @@ const Chat = () => {
                         aria-pressed={!isWorkMode}
                         onClick={selectWebMode}
                     >
-                        <p className={styles.modeToggleText}>LM</p>
+                        <p className={styles.modeToggleText}>Chat</p>
                     </div>
                 </div>
                     {!lastQuestionRef.current ? (

--- a/frontend/src/pages/chat/Chat.tsx
+++ b/frontend/src/pages/chat/Chat.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from "react";
-import { Checkbox, Panel, DefaultButton, TextField, SpinButton } from "@fluentui/react";
+import { Checkbox, Panel, DefaultButton, TextField, SpinButton, Toggle } from "@fluentui/react";
 import { SparkleFilled, TabDesktopMultipleBottomRegular } from "@fluentui/react-icons";
 import { getLanguageText } from '../../utils/languageUtils'; 
 
@@ -48,6 +48,10 @@ const Chat = () => {
     const [userId, setUserId] = useState<string>("");
     const triggered = useRef(false);
 
+    const [isWorkMode, setIsWorkMode] = useState<boolean>(true);
+
+    const selectWorkMode = () => setIsWorkMode(true);
+    const selectWebMode = () => setIsWorkMode(false);
 
     const makeApiRequestGpt = async (question: string) => {
         lastQuestionRef.current = question;
@@ -63,6 +67,7 @@ const Chat = () => {
                 history: [...history, { user: question, bot: undefined }],
                 approach: Approaches.ReadRetrieveRead,
                 conversation_id: userId,
+                is_work_mode: isWorkMode,
                 query: question,
                 overrides: {
                     promptTemplate: promptTemplate.length === 0 ? undefined : promptTemplate,
@@ -269,6 +274,28 @@ const Chat = () => {
             </div>
             <div className={styles.chatRoot}>
                 <div className={styles.chatContainer}>
+                <div className={styles.modeToggleContainer}>
+                    <div
+                        id="mode-work"
+                        role="button"
+                        tabIndex={0}
+                        className={`${styles.modeToggleButton} ${isWorkMode ? styles.activeMode : ""}`}
+                        aria-pressed={isWorkMode}
+                        onClick={selectWorkMode}
+                    >
+                        <p className={styles.modeToggleText}>Work</p>
+                    </div>
+                    <div
+                        id="mode-web"
+                        role="button"
+                        tabIndex={0}
+                        className={`${styles.modeToggleButton} ${!isWorkMode ? styles.activeMode : ""}`}
+                        aria-pressed={!isWorkMode}
+                        onClick={selectWebMode}
+                    >
+                        <p className={styles.modeToggleText}>LM</p>
+                    </div>
+                </div>
                     {!lastQuestionRef.current ? (
                         <div className={styles.chatEmptyState}>
                         </div>


### PR DESCRIPTION
## Purpose

This PR adds a new Work/LM mode toggle feature to the chat interface, allowing users to switch between two different interaction modes:

Work mode: Focuses queries on work-related content and knowledge bases
LM mode: Uses the language model's general knowledge for wider topic coverage
The implementation adds a UI toggle in the chat interface and passes the selected mode to the backend API via the [is_work_mode](vscode-file://vscode-app/c:/Users/christava/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) parameter, enabling the backend to provide context-appropriate responses based on the selected mode.

## Type of change

```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Related Backlog Item or Issue

If applicable, provide a link to the relevant backlog item or issue.

<!-- Example: https://github.com/placerda/gpt-rag-orchestrator/issues/123 -->

## Is this change disruptive or does it break existing applications?

If deploying this change could impact existing applications, please specify.

```
[ ] Yes
[X] No
```

## Cross-Repository Dependencies

If this change depends on pull requests in other repositories within the solution, provide the links below.

- [ ] [gpt-rag](https://github.com/azure/gpt-rag) <!-- Example: — Link: https://github.com/placerda/gpt-rag-orchestrator/pull/456 -->
- [ ] [gpt-rag-agentic](https://github.com/azure/gpt-rag) <!-- Example: — Link: https://github.com/placerda/gpt-rag/pull/456 -->
- [ ] [gpt-rag-ingestion](https://github.com/azure/gpt-rag-ingestion) <!-- Example: — Link: https://github.com/placerda/gpt-rag-ingestion/pull/456 -->
- [ ] [gpt-rag-orchestrator](https://github.com/azure/gpt-rag-orchestrator) <!-- Example: — Link: https://github.com/placerda/gpt-rag-frontend/pull/456 -->

## Does this require changes to project documentation?

If the changes add new functionality, update the documentation accordingly.

```
[X] Yes
[ ] No
```

## Documentation Link

If this change adds a new functionality, provide a link to its documentation.

<!-- Example: https://github.com/placerda/gpt-rag-orchestrator/wiki/New-Feature-Guide -->

## Code quality checklist

- [X] I verified the changes locally to ensure they work as expected
- [ ] I have tested the new functionality and ensured existing features still work
- [ ] I have updated the CHANGELOG.md file to document these changes
- [ ] I have reviewed the code for readability, maintainability, and adherence to project conventions
- [ ] I have added at least two reviewers to the Pull Request

Screenshot of working code

![screenshot](https://github.com/user-attachments/assets/3b11a240-c64a-46df-b325-df8ab55c60a4)


## Contributing guidelines

See [CONTRIBUTING.md](https://github.com/Azure/GPT-RAG/blob/main/CONTRIBUTING.md) for more details.
